### PR TITLE
fix gpu device

### DIFF
--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -107,12 +107,12 @@ def run_task(processor, args):
         segmentation_model = segmentation_model_factory(
             args.segmenter,
             confidence_thresh=args.seg_conf_thresh,
-            device=f'cuda:{args.gpu}'
+            device=args.device
         )
         if args.remove_artifacts:
             artifact_remover_model = segmentation_model_factory(
                 'grandqc_artifact',
-                device=f'cuda:{args.gpu}'
+                device=args.device
             )
         else:
             artifact_remover_model = None
@@ -143,7 +143,7 @@ def run_task(processor, args):
             processor.run_patch_feature_extraction_job(
                 coords_dir=args.coords_dir or f'{args.mag}x_{args.patch_size}px_{args.overlap}px_overlap',
                 patch_encoder=encoder,
-                device=f'cuda:{args.gpu}',
+                device=args.device,
                 saveas='h5',
                 batch_limit=args.batch_size,
             )
@@ -155,7 +155,7 @@ def run_task(processor, args):
             processor.run_slide_feature_extraction_job(
                 slide_encoder=encoder,
                 coords_dir=args.coords_dir or f'{args.mag}x_{args.patch_size}px_{args.overlap}px_overlap',
-                device=f'cuda:{args.gpu}',
+                device=args.device,
                 saveas='h5',
                 batch_limit=args.batch_size
             )
@@ -167,7 +167,14 @@ def main():
     processor = initialize_processor(args)
 
     # ensure cuda is available
-    args.device = f'cuda:{args.gpu}' if torch.cuda.is_available() else 'cpu'
+    if torch.cuda.is_available():
+        args.device = f'cuda:{args.gpu}'
+
+    elif torch.backends.mps.is_available():
+        args.device = 'mps'
+
+    else:
+        args.device = 'cpu'
 
     if args.task == 'all':
         args.task = 'seg'

--- a/run_single_slide.py
+++ b/run_single_slide.py
@@ -8,6 +8,7 @@ python run_single_slide.py --slide_path output/wsis/394140.svs --job_dir output/
 """
 import argparse
 import os
+import torch
 
 from trident import OpenSlideWSI
 from trident.segmentation_models import segmentation_model_factory
@@ -60,7 +61,7 @@ def process_slide(args):
     segmentation_model = segmentation_model_factory(
         model_name=args.segmenter,
         confidence_thresh=args.seg_conf_thresh,
-        device=f"cuda:{args.gpu}"
+        device=args.device
     )
     slide.segment_tissue(
         segmentation_model=segmentation_model,
@@ -91,13 +92,13 @@ def process_slide(args):
     print("Extracting features from patches...")
     encoder = encoder_factory(args.patch_encoder)
     encoder.eval()
-    encoder.to(f"cuda:{args.gpu}")
+    encoder.to(args.device)
     features_path = features_dir = os.path.join(save_coords, "features_{}".format(args.patch_encoder))
     slide.extract_patch_features(
         patch_encoder=encoder,
         coords_path=os.path.join(save_coords, 'patches', f'{slide.name}_patches.h5'),
         save_features=features_dir,
-        device=f"cuda:{args.gpu}",
+        device=args.device,
         batch_limit=args.batch_size
     )
     print(f"Feature extraction completed. Results saved to {features_path}")
@@ -105,6 +106,17 @@ def process_slide(args):
 
 def main():
     args = parse_arguments()
+
+    # ensure cuda is available
+    if torch.cuda.is_available():
+        args.device = f"cuda:{args.gpu}"
+
+    elif torch.backends.mps.is_available():
+        args.device = "mps"
+
+    else:
+        args.device = "cpu"
+
     process_slide(args)
 
 

--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -407,7 +407,6 @@ class OpenSlideWSI:
         return None
 
     @torch.inference_mode()
-    @torch.autocast(device_type="cuda", dtype=torch.float16)
     def segment_tissue(
         self,
         segmentation_model: torch.nn.Module,
@@ -836,7 +835,7 @@ class OpenSlideWSI:
         features = []
         for imgs, _ in dataloader:
             imgs = imgs.to(device)
-            with torch.autocast(device_type='cuda', dtype=precision, enabled=(precision != torch.float32)):
+            with torch.autocast(device_type=device.split(":")[0], dtype=precision, enabled=(precision != torch.float32)):
                 batch_features = patch_encoder(imgs)  
             features.append(batch_features.cpu().numpy())
 
@@ -940,7 +939,7 @@ class OpenSlideWSI:
         }
 
         # Generate slide-level features
-        with torch.autocast(device_type='cuda', enabled=(slide_encoder.precision != torch.float32)):
+        with torch.autocast(device_type=device.split(":")[0], enabled=(slide_encoder.precision != torch.float32)):
             features = slide_encoder(batch, device)
         features = features.float().cpu().numpy().squeeze()
 


### PR DESCRIPTION
This pull request updates device handling across multiple files to improve compatibility with different hardware accelerators (e.g., CUDA, MPS, or CPU). The changes ensure that the code dynamically selects the appropriate device based on availability, making it more robust and portable. Additionally, adjustments have been made to the `torch.autocast` functionality to align with these updates.

### Device Handling Updates:
* [`run_batch_of_slides.py`](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L110-R115): Updated `args.device` initialization in `main()` to dynamically select between CUDA, MPS, or CPU based on availability. Replaced all instances of `f'cuda:{args.gpu}'` with `args.device` in `run_task()` for segmentation, patch feature extraction, and slide feature extraction. [[1]](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L110-R115) [[2]](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L146-R146) [[3]](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L158-R158) [[4]](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L170-R177)
* [`run_single_slide.py`](diffhunk://#diff-a0275c427c4b7a41282cf4d95af2ce2bbd2ad4dcf2e4e1e2e965b05e90550cd0R11): Added dynamic device selection in `main()` and replaced hardcoded CUDA device strings with `args.device` in `process_slide()`. [[1]](diffhunk://#diff-a0275c427c4b7a41282cf4d95af2ce2bbd2ad4dcf2e4e1e2e965b05e90550cd0R11) [[2]](diffhunk://#diff-a0275c427c4b7a41282cf4d95af2ce2bbd2ad4dcf2e4e1e2e965b05e90550cd0L63-R64) [[3]](diffhunk://#diff-a0275c427c4b7a41282cf4d95af2ce2bbd2ad4dcf2e4e1e2e965b05e90550cd0L94-R119)

### Compatibility with `torch.autocast`:
* [`trident/wsi_objects/WSI.py`](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL410): Modified `torch.autocast` calls in `extract_patch_features()` and `extract_slide_features()` to use the dynamically selected device type (`device.split(":")[0]`) instead of hardcoded `"cuda"`. Removed redundant `torch.autocast` decorator from `segment_tissue()`. [[1]](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL410) [[2]](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL839-R838) [[3]](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL943-R942)