### PR TITLE
Enable Apple Silicon functionality with MPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,87 @@
+# Operating System Files
+.DS_Store
+Thumbs.db
+*.swp
+*.lock
+Desktop.ini
+
+# IDE and Editor Files
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+.project
+.classpath
+.settings/
+*.code-workspace
+
+# Build and Dependency Directories
+node_modules/
+bower_components/
+dist/
+build/
+target/
+out/
+bin/
+obj/
+lib/
+
+# Package Manager Files
+npm-debug.log
+yarn-error.log
+yarn-debug.log
+package-lock.json
+yarn.lock
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+ENV/
+.env
+.venv
+env.bak/
+venv.bak/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Java
+*.class
+*.jar
+*.war
+*.ear
+*.log
+
+# Logs and Databases
+*.log
+*.sql
+*.sqlite
+*.sqlite3
+*.db
+
+# Compiled Source
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Temporary Files
+*.bak
+*.tmp
+*~
+*.swp
+*.swo
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Project-specific files (add as needed)
+# config.json
+# secrets.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ Thumbs.db
 *.swp
 *.lock
 Desktop.ini
+/test_data
+/trident_processed
 
 # IDE and Editor Files
 .idea/

--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -175,7 +175,7 @@ def run_task(processor, args):
             holes_are_tissue= not args.remove_holes,
             artifact_remover_model=artifact_remover_model,
             batch_size=args.seg_batch_size if args.seg_batch_size is not None else args.batch_size,
-            device=f'cuda:{args.gpu}',
+            device=args.device,
         )
     elif args.task == 'coords':
         processor.run_patching_job(
@@ -192,7 +192,7 @@ def run_task(processor, args):
             processor.run_patch_feature_extraction_job(
                 coords_dir=args.coords_dir or f'{args.mag}x_{args.patch_size}px_{args.overlap}px_overlap',
                 patch_encoder=encoder,
-                device=f'cuda:{args.gpu}',
+                device=args.device,
                 saveas='h5',
                 batch_limit=args.feat_batch_size if args.feat_batch_size is not None else args.batch_size,
             )
@@ -202,7 +202,7 @@ def run_task(processor, args):
             processor.run_slide_feature_extraction_job(
                 slide_encoder=encoder,
                 coords_dir=args.coords_dir or f'{args.mag}x_{args.patch_size}px_{args.overlap}px_overlap',
-                device=f'cuda:{args.gpu}',
+                device=args.device,
                 saveas='h5',
                 batch_limit=args.feat_batch_size if args.feat_batch_size is not None else args.batch_size,
             )
@@ -213,7 +213,14 @@ def run_task(processor, args):
 def main():
 
     args = parse_arguments()
-    args.device = f'cuda:{args.gpu}' if torch.cuda.is_available() else 'cpu'
+    if torch.cuda.is_available():
+        args.device = f'cuda:{args.gpu}'
+
+    elif torch.backends.mps.is_available():
+        args.device = 'mps'
+
+    else:
+        args.device = 'cpu'
 
     if args.wsi_cache:
         # === Parallel pipeline with caching ===

--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -221,6 +221,7 @@ def main():
 
     else:
         args.device = 'cpu'
+    print(f"[MAIN] Using device: {args.device}")
 
     if args.wsi_cache:
         # === Parallel pipeline with caching ===

--- a/run_single_slide.py
+++ b/run_single_slide.py
@@ -8,6 +8,7 @@ python run_single_slide.py --slide_path output/wsis/394140.svs --job_dir output/
 """
 import argparse
 import os
+import torch
 
 from trident import load_wsi
 from trident.segmentation_models import segmentation_model_factory
@@ -65,7 +66,7 @@ def process_slide(args):
         segmentation_model=segmentation_model,
         target_mag=segmentation_model.target_mag,
         job_dir=args.job_dir,
-        device=f"cuda:{args.gpu}"
+        device=args.device
     )
     print(f"Tissue segmentation completed. Results saved to {args.job_dir}contours_geojson and {args.job_dir}contours")
 
@@ -97,7 +98,7 @@ def process_slide(args):
         patch_encoder=encoder,
         coords_path=os.path.join(save_coords, 'patches', f'{slide.name}_patches.h5'),
         save_features=features_dir,
-        device=f"cuda:{args.gpu}",
+        device=args.device,
         batch_limit=args.batch_size
     )
     print(f"Feature extraction completed. Results saved to {features_path}")
@@ -105,6 +106,17 @@ def process_slide(args):
 
 def main():
     args = parse_arguments()
+
+    # ensure cuda is available
+    if torch.cuda.is_available():
+        args.device = f"cuda:{args.gpu}"
+
+    elif torch.backends.mps.is_available():
+        args.device = "mps"
+
+    else:
+        args.device = "cpu"
+        
     process_slide(args)
 
 

--- a/run_single_slide.py
+++ b/run_single_slide.py
@@ -92,7 +92,7 @@ def process_slide(args):
     print("Extracting features from patches...")
     encoder = encoder_factory(args.patch_encoder)
     encoder.eval()
-    encoder.to(f"cuda:{args.gpu}")
+    encoder.to(args.device)
     features_path = features_dir = os.path.join(save_coords, "features_{}".format(args.patch_encoder))
     slide.extract_patch_features(
         patch_encoder=encoder,
@@ -116,7 +116,7 @@ def main():
 
     else:
         args.device = "cpu"
-        
+
     process_slide(args)
 
 

--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -246,7 +246,6 @@ class WSI:
                 raise ValueError(f"Identified mpp is very low: mpp={mpp_x}. Most WSIs are at 20x, 40x magnfication.")
 
     @torch.inference_mode()
-    @torch.autocast(device_type="cuda", dtype=torch.float16)
     def segment_tissue(
         self,
         segmentation_model: torch.nn.Module,
@@ -649,7 +648,7 @@ class WSI:
         features = []
         for imgs, _ in dataloader:
             imgs = imgs.to(device)
-            with torch.autocast(device_type='cuda', dtype=precision, enabled=(precision != torch.float32)):
+            with torch.autocast(device_type=device.split(":")[0], dtype=precision, enabled=(precision != torch.float32)):
                 batch_features = patch_encoder(imgs)  
             features.append(batch_features.cpu().numpy())
 
@@ -753,7 +752,7 @@ class WSI:
         }
 
         # Generate slide-level features
-        with torch.autocast(device_type='cuda', enabled=(slide_encoder.precision != torch.float32)):
+        with torch.autocast(device_type=device.split(":")[0], enabled=(slide_encoder.precision != torch.float32)):
             features = slide_encoder(batch, device)
         features = features.float().cpu().numpy().squeeze()
 

--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import numpy as np
 from PIL import Image
 import os 
+import sys
 import warnings
 import torch 
 from typing import List, Tuple, Optional, Literal
@@ -312,7 +313,14 @@ class WSI:
         precision = segmentation_model.precision
         eval_transforms = segmentation_model.eval_transforms
         dataset = WSIPatcherDataset(patcher, eval_transforms)
-        dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=get_num_workers(batch_size, max_workers=self.max_workers), pin_memory=True)
+        # dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=get_num_workers(batch_size, max_workers=self.max_workers), pin_memory=True)
+        if sys.platform == "linux":
+            dataloader = DataLoader(dataset, 
+                                    batch_size=batch_size, 
+                                    num_workers=get_num_workers(batch_size, max_workers=self.max_workers), 
+                                    pin_memory=True)  
+        else:
+            dataloader = DataLoader(dataset, batch_size=batch_size, pin_memory=True)
         # dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=0, pin_memory=True)
 
         mpp_reduction_factor = self.mpp / destination_mpp
@@ -642,7 +650,14 @@ class WSI:
             pil=True,
         )
         dataset = WSIPatcherDataset(patcher, patch_transforms)
-        dataloader = DataLoader(dataset, batch_size=batch_limit, num_workers=get_num_workers(batch_limit, max_workers=self.max_workers), pin_memory=True)
+        #dataloader = DataLoader(dataset, batch_size=batch_limit, num_workers=get_num_workers(batch_limit, max_workers=self.max_workers), pin_memory=True)
+        if sys.platform == "linux":
+            dataloader = DataLoader(dataset, 
+                                    batch_size=batch_limit, 
+                                    num_workers=get_num_workers(batch_limit, max_workers=self.max_workers), 
+                                    pin_memory=True)  
+        else:
+            dataloader = DataLoader(dataset, batch_size=batch_limit, pin_memory=True)
         # dataloader = DataLoader(dataset, batch_size=batch_limit, num_workers=0, pin_memory=True)
 
         features = []

--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -254,7 +254,7 @@ class WSI:
         holes_are_tissue: bool = True,
         job_dir: Optional[str] = None,
         batch_size: int = 16,
-        device: str = 'cuda:0',
+        device: str = 'auto',  # Changed default from 'cuda:0' to 'auto'
         verbose=False
     ) -> str:
         """
@@ -275,7 +275,7 @@ class WSI:
         batch_size : int, optional
             Batch size for processing patches. Defaults to 16.
         device (str): 
-            The computation device to use (e.g., 'cuda:0' for GPU or 'cpu' for CPU).
+            The computation device to use ('auto', 'cuda:0', 'mps', 'cpu'). 'auto' will select the best available.
         verbose: bool, optional:
             Whenever to print segmentation progress. Defaults to False.
 
@@ -292,7 +292,19 @@ class WSI:
         """
 
         self._lazy_initialize()
-        segmentation_model.to(device)
+        
+        # Auto-detect best available device if set to 'auto'
+        if device == 'auto':
+            if torch.cuda.is_available():
+                device = 'cuda:0'
+            elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+                device = 'mps'
+            else:
+                device = 'cpu'
+        
+        print(f"Using device: {device} for tissue segmentation")
+        
+        segmentation_model.to(device)  # Fixed: use the device parameter, not args.device
         max_dimension = 1000
         if self.width > self.height:
             thumbnail_width = max_dimension


### PR DESCRIPTION
This pull request introduces significant updates to improve device compatibility across scripts and modules, ensuring support for CUDA, MPS, and CPU environments. Additionally, it includes adjustments to data loading logic for platform-specific optimizations and removes hardcoded device types in favor of dynamic detection.

### Device compatibility improvements:
* [`run_batch_of_slides.py`](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L178-R178): Updated logic to dynamically set `args.device` based on available hardware (CUDA, MPS, or CPU) and replaced hardcoded `f'cuda:{args.gpu}'` with `args.device` in multiple processing functions. [[1]](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L178-R178) [[2]](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L195-R195) [[3]](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L205-R205) [[4]](diffhunk://#diff-6000cf7d36c65e15b9baa8a8dac69a886ace172cbb1ad1d0d6d77e0b7c1468b1L216-R223)
* [`run_single_slide.py`](diffhunk://#diff-a0275c427c4b7a41282cf4d95af2ce2bbd2ad4dcf2e4e1e2e965b05e90550cd0L68-R69): Added dynamic device detection and replaced hardcoded `f"cuda:{args.gpu}"` with `args.device` in feature extraction and segmentation processes. [[1]](diffhunk://#diff-a0275c427c4b7a41282cf4d95af2ce2bbd2ad4dcf2e4e1e2e965b05e90550cd0L68-R69) [[2]](diffhunk://#diff-a0275c427c4b7a41282cf4d95af2ce2bbd2ad4dcf2e4e1e2e965b05e90550cd0L94-R119)

### Platform-specific optimizations:
* [`trident/wsi_objects/WSI.py`](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL316-R323): Modified `DataLoader` initialization to conditionally set `num_workers` based on the platform (`linux` vs. others) for better compatibility. [[1]](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL316-R323) [[2]](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL646-R666)

### Code cleanup and dynamic device handling:
* [`trident/wsi_objects/WSI.py`](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL646-R666): Adjusted `torch.autocast` calls to dynamically determine `device_type` based on `args.device` instead of hardcoding `'cuda'`. [[1]](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL646-R666) [[2]](diffhunk://#diff-60ceb8ae9259f75e0a4ef5aba649061ce02b3a1af4aaca323d0cea6b55fcdffbL756-R770)
* Removed `@torch.autocast` decorator from `segment_tissue` method to streamline code.